### PR TITLE
Replaced argument `sym_pos` with `assume_a="pos"`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 */__pycache__/
 */.ipynb_checkpoints/
 *.pyc
+parsmooth.egg-info/

--- a/parsmooth/parallel/_filtering.py
+++ b/parsmooth/parallel/_filtering.py
@@ -82,7 +82,7 @@ def _standard_associative_params_one(linearization_method, transition_model, obs
     P = F @ P @ F.T + Q
 
     S = H @ P @ H.T + R
-    S_invH = jlinalg.solve(S, H, sym_pos=True)
+    S_invH = jlinalg.solve(S, H, assume_a="pos")
     K = (S_invH @ P).T
     A = F - K @ H @ F
 

--- a/parsmooth/parallel/_operators.py
+++ b/parsmooth/parallel/_operators.py
@@ -29,8 +29,8 @@ def standard_filtering_operator(elem1, elem2):
     IpCJ = I_dim + jnp.dot(C1, J2)
     IpJC = I_dim + jnp.dot(J2, C1)
 
-    AIpCJ_inv = jlinalg.solve(IpCJ.T, A2.T, sym_pos=False).T
-    AIpJC_inv = jlinalg.solve(IpJC.T, A1, sym_pos=False).T
+    AIpCJ_inv = jlinalg.solve(IpCJ.T, A2.T).T
+    AIpJC_inv = jlinalg.solve(IpJC.T, A1).T
 
     A = jnp.dot(AIpCJ_inv, A1)
     b = jnp.dot(AIpCJ_inv, b1 + jnp.dot(C1, eta2)) + b2

--- a/parsmooth/parallel/_smoothing.py
+++ b/parsmooth/parallel/_smoothing.py
@@ -60,7 +60,7 @@ def _standard_associative_params(linearization_method, transition_model, n_k_1, 
     F, Q, b = linearization_method(transition_model, n_k_1)
     Pp = F @ P @ F.T + Q
 
-    E = jlinalg.solve(Pp, F @ P, sym_pos=True).T
+    E = jlinalg.solve(Pp, F @ P, assume_a="pos").T
 
     g = m - E @ (F @ m + b)
     L = P - E @ Pp @ E.T

--- a/parsmooth/sequential/_smoothing.py
+++ b/parsmooth/sequential/_smoothing.py
@@ -49,7 +49,7 @@ def _standard_smooth(F, Q, b, xf, xs):
     S = F @ Pf @ F.T + Q
     cov_diff = Ps - S
 
-    gain = Pf @ jlag.solve(S, F, sym_pos=True).T
+    gain = Pf @ jlag.solve(S, F, assume_a="pos").T
     ms = mf + gain @ mean_diff
     Ps = Pf + gain @ cov_diff @ gain.T
 


### PR DESCRIPTION
## What?
Replaced the `sym_pos=True` argument to `jax.linalg.solve` with `assume_a="pos"`.

## Why?
Deprecation warning when using `sym_pos`.